### PR TITLE
Omniref query page has changed

### DIFF
--- a/omniref.el
+++ b/omniref.el
@@ -24,7 +24,7 @@
 
 (require 'browse-url)
 
-(defconst omniref-url "http://www.omniref.com/?q="
+(defconst omniref-url "http://docs.omniref.com/?q="
   "Omniref query URL")
 
 (defun omniref-formatted-search-term (terms)


### PR DESCRIPTION
When using www.omniref.com it shows only the new page offering a new service for source code annotation.
